### PR TITLE
feat: add initial StateHandler

### DIFF
--- a/examples/flutter_timer_state_machine/pubspec.yaml
+++ b/examples/flutter_timer_state_machine/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
-
+  sdk: '>=3.0.1 <4.0.0'
+  
 dependencies:
   flutter:
     sdk: flutter

--- a/examples/infinite_list_state_machine/pubspec.yaml
+++ b/examples/infinite_list_state_machine/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: '>=3.0.1 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/state_machine_bloc/lib/src/state_handler.dart
+++ b/packages/state_machine_bloc/lib/src/state_handler.dart
@@ -1,5 +1,39 @@
 part of 'state_machine.dart';
 
+/// {@template state_handler}
+/// A class that provides encapsulation for event handling, improving readability
+/// and testability for a given state.
+///
+/// ```dart
+/// class InitialStateHandler extends StateHandler<Event, State, InitialState> {
+///   @override
+///   registerEventHandlers() {
+///     on<SomeEvent>((SomeEvent event, InitialState state) => OtherState());
+///   }
+///
+///   @override
+///   Future<void> onEnter(state) async {
+///     print('in onEnter');
+///   }
+///
+///   @override
+///   Future<void> onExit(state) async {
+///     print('in onExit');
+///   }
+///
+///   @override
+///   Future<void> onChange(previous, next) async {
+///     print('in onChange: $previous $next');
+///   }
+/// }
+///
+/// class MyStateMachine extends StateMachine<Event, State> {
+/// MyStateMachine() : super(InitialState()) {
+///    defineHandler<InitialState>(InitialStateHandler())
+///    define<OtherState>();
+///   }
+/// }
+/// ```
 abstract class StateHandler<Event, State, DefinedState extends State> {
   final StateDefinitionBuilder<Event, State, DefinedState> _builder =
       StateDefinitionBuilder<Event, State, DefinedState>();
@@ -16,6 +50,8 @@ abstract class StateHandler<Event, State, DefinedState extends State> {
     _addFn = fn;
   }
 
+  /// Add an event to the enclosing [StateMachine] where this [StateHandler]
+  /// is registered.
   void Function(Event event) get add {
     assert(() {
       if (_addFn == null) {
@@ -28,16 +64,34 @@ abstract class StateHandler<Event, State, DefinedState extends State> {
     return _addFn!;
   }
 
+  /// Register event handlers for the [DefinedState].
   void registerEventHandlers();
 
+  /// Register [onEnterCallback] function as onExit side effect for [DefinedState]
+  /// See also:
+  ///
+  /// * [StateDefinitionBuilder.onExit] for more information
   FutureOr<void> onEnter(DefinedState state) {}
+
+  /// Register [onExitCallback] function as onExit side effect for [DefinedState]
+  /// See also:
+  ///
+  /// * [StateDefinitionBuilder.onExit] for more information
   FutureOr<void> onExit(DefinedState state) {}
+
+  /// Register [onChangeCallback] function as onExit side effect for [DefinedState]
+  /// See also:
+  ///
+  /// * [StateDefinitionBuilder.onExit] for more information
   FutureOr<void> onChange(DefinedState currentState, DefinedState nextState) {}
 
+  /// Register [transition] function as one of [DefinedState]'s event handler
+  /// for [DefinedEvent]
   void on<DefinedEvent extends Event>(
     EventTransition<DefinedEvent, State, DefinedState> transition,
   ) =>
       _builder.on<DefinedEvent>(transition);
 
+  // Build the internal [StateDefinitionBuilder] to generate a [StateDefinition]
   _StateDefinition<Event, State, DefinedState> _build() => _builder._build();
 }

--- a/packages/state_machine_bloc/lib/src/state_handler.dart
+++ b/packages/state_machine_bloc/lib/src/state_handler.dart
@@ -37,53 +37,41 @@ part of 'state_machine.dart';
 abstract class StateHandler<Event, State, DefinedState extends State> {
   final StateDefinitionBuilder<Event, State, DefinedState> _builder =
       StateDefinitionBuilder<Event, State, DefinedState>();
-  void Function(Event event)? _addFn;
-
-  set add(Function(Event event) fn) {
-    assert(() {
-      if (_addFn != null) {
-        throw 'Tried to add an `add` handler twice. This setter should only be '
-            'called once.';
-      }
-      return true;
-    }());
-    _addFn = fn;
-  }
-
-  /// Add an event to the enclosing [StateMachine] where this [StateHandler]
-  /// is registered.
-  void Function(Event event) get add {
-    assert(() {
-      if (_addFn == null) {
-        throw 'Add function has not be applied to the handler. '
-            'Please use `add` setter to apply it.';
-      }
-      return true;
-    }());
-
-    return _addFn!;
-  }
 
   /// Register event handlers for the [DefinedState].
   void registerEventHandlers();
 
   /// Register [onEnterCallback] function as onExit side effect for [DefinedState]
+  ///
+  /// Returns a [FutureOr<Event?>], and any event returned will be added to
+  /// the [StateMachine] where this [StateHandler] is registered.
+  ///
   /// See also:
   ///
   /// * [StateDefinitionBuilder.onExit] for more information
-  FutureOr<void> onEnter(DefinedState state) {}
+  FutureOr<Event?> onEnter(DefinedState state) => null;
 
   /// Register [onExitCallback] function as onExit side effect for [DefinedState]
+  ///
+  /// Returns a [FutureOr<Event?>], and any event returned will be added to
+  /// the [StateMachine] where this [StateHandler] is registered.
+  ///
   /// See also:
   ///
   /// * [StateDefinitionBuilder.onExit] for more information
-  FutureOr<void> onExit(DefinedState state) {}
+  FutureOr<Event?> onExit(DefinedState state) => null;
 
   /// Register [onChangeCallback] function as onExit side effect for [DefinedState]
+  ///
+  /// Returns a [FutureOr<Event?>], and any event returned will be added to
+  /// the [StateMachine] where this [StateHandler] is registered.
+  ///
   /// See also:
   ///
   /// * [StateDefinitionBuilder.onExit] for more information
-  FutureOr<void> onChange(DefinedState currentState, DefinedState nextState) {}
+  FutureOr<Event?> onChange(
+          DefinedState currentState, DefinedState nextState) =>
+      null;
 
   /// Register [transition] function as one of [DefinedState]'s event handler
   /// for [DefinedEvent]

--- a/packages/state_machine_bloc/lib/src/state_handler.dart
+++ b/packages/state_machine_bloc/lib/src/state_handler.dart
@@ -1,0 +1,34 @@
+part of 'state_machine.dart';
+
+abstract class StateHandler<Event, State, DefinedState extends State> {
+  final StateDefinitionBuilder<Event, State, DefinedState> _builder =
+      StateDefinitionBuilder<Event, State, DefinedState>();
+  void Function(Event event)? _addFn;
+
+  set add(Function(Event event) fn) => _addFn = fn;
+  void Function(Event event) get add {
+    assert(() {
+      if (_addFn == null) {
+        throw 'Add function has not be applied to the handler. '
+            'Please use `add` setter to apply it.';
+      }
+      return true;
+    }());
+
+    return _addFn!;
+  }
+
+  void registerEventHandlers();
+
+  Future<void> onEnter(DefinedState state) async {}
+  Future<void> onExit(DefinedState state) async {}
+  Future<void> onChange(
+      DefinedState currentState, DefinedState nextState) async {}
+
+  void on<DefinedEvent extends Event>(
+    EventTransition<DefinedEvent, State, DefinedState> transition,
+  ) =>
+      _builder.on<DefinedEvent>(transition);
+
+  _StateDefinition<Event, State, DefinedState> _build() => _builder._build();
+}

--- a/packages/state_machine_bloc/lib/src/state_handler.dart
+++ b/packages/state_machine_bloc/lib/src/state_handler.dart
@@ -5,7 +5,17 @@ abstract class StateHandler<Event, State, DefinedState extends State> {
       StateDefinitionBuilder<Event, State, DefinedState>();
   void Function(Event event)? _addFn;
 
-  set add(Function(Event event) fn) => _addFn = fn;
+  set add(Function(Event event) fn) {
+    assert(() {
+      if (_addFn != null) {
+        throw 'Tried to add an `add` handler twice. This setter should only be '
+            'called once.';
+      }
+      return true;
+    }());
+    _addFn = fn;
+  }
+
   void Function(Event event) get add {
     assert(() {
       if (_addFn == null) {
@@ -20,10 +30,9 @@ abstract class StateHandler<Event, State, DefinedState extends State> {
 
   void registerEventHandlers();
 
-  Future<void> onEnter(DefinedState state) async {}
-  Future<void> onExit(DefinedState state) async {}
-  Future<void> onChange(
-      DefinedState currentState, DefinedState nextState) async {}
+  FutureOr<void> onEnter(DefinedState state) {}
+  FutureOr<void> onExit(DefinedState state) {}
+  FutureOr<void> onChange(DefinedState currentState, DefinedState nextState) {}
 
   void on<DefinedEvent extends Event>(
     EventTransition<DefinedEvent, State, DefinedState> transition,

--- a/packages/state_machine_bloc/lib/src/state_machine.dart
+++ b/packages/state_machine_bloc/lib/src/state_machine.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:meta/meta.dart';

--- a/packages/state_machine_bloc/lib/src/state_machine.dart
+++ b/packages/state_machine_bloc/lib/src/state_machine.dart
@@ -272,8 +272,6 @@ abstract class StateMachine<Event, State> extends Bloc<Event, State> {
       return true;
     }());
 
-    if (!isClosed) {
-      add(event);
-    }
+    add(event);
   }
 }

--- a/packages/state_machine_bloc/lib/src/state_machine.dart
+++ b/packages/state_machine_bloc/lib/src/state_machine.dart
@@ -130,6 +130,51 @@ abstract class StateMachine<Event, State> extends Bloc<Event, State> {
     }
   }
 
+  /// Register a [StateHandler<Event, State, DefinedState>] as one of the
+  /// allowed machine's states.
+  ///
+  /// A [StateHandler<Event, State, DefinedState>] allows for breaking up the
+  /// business logic of a given state into smaller units of code, potentially
+  /// increasing readability and testability.
+  ///
+  /// Simply extend [StateHandler<Event, State, DefinedState>] and utilize the
+  /// available methods to create [onEnter], [onExit], [onChange], and [on]
+  /// handlers for a given [DefinedState].
+  ///
+  /// Handlers have an available [add] method to add new events to the bloc. All
+  /// defined handlers operate the same as using [StateDefinitionBuilder]
+  /// directly.
+  ///
+  /// ```dart
+  /// class InitialStateHandler extends StateHandler<Event, State, InitialState> {
+  ///   @override
+  ///   registerEventHandlers() {
+  ///     on<SomeEvent>((SomeEvent event, InitialState state) => OtherState());
+  ///   }
+  ///
+  ///   @override
+  ///   Future<void> onEnter(state) async {
+  ///     print('in onEnter');
+  ///   }
+  ///
+  ///   @override
+  ///   Future<void> onExit(state) async {
+  ///     print('in onExit');
+  ///   }
+  ///
+  ///   @override
+  ///   Future<void> onChange(previous, next) async {
+  ///     print('in onChange: $previous $next');
+  ///   }
+  /// }
+  ///
+  /// class MyStateMachine extends StateMachine<Event, State> {
+  /// MyStateMachine() : super(InitialState()) {
+  ///    defineHandler<InitialState>(InitialStateHandler())
+  ///    define<OtherState>();
+  ///   }
+  /// }
+  /// ```
   void defineHandler<DefinedState extends State>(
       StateHandler<Event, State, DefinedState> handler) {
     final builder = handler._builder;

--- a/packages/state_machine_bloc/pubspec.yaml
+++ b/packages/state_machine_bloc/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Pierre2tm/state_machine_bloc
 repository: https://github.com/Pierre2tm/state_machine_bloc
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: '>=3.0.1 <4.0.0'
 
 dev_dependencies:
   lints: ^1.0.0

--- a/packages/state_machine_bloc/test/state_handler_test.dart
+++ b/packages/state_machine_bloc/test/state_handler_test.dart
@@ -68,18 +68,8 @@ class StateBHandler extends StateHandler<Event, State, StateB> {
   }
 
   @override
-  Future<void> onEnter(state) async {
-    print('in onEnter');
-  }
-
-  @override
   Future<void> onExit(state) async {
     print('in onExit');
-  }
-
-  @override
-  Future<void> onChange(previous, next) async {
-    print('in onChange: $previous $next');
   }
 }
 
@@ -98,21 +88,6 @@ class StateCHandler extends StateHandler<Event, State, StateC> {
   StateA _onC(EventC event, StateC state) {
     _onEvent(event);
     return StateA();
-  }
-
-  @override
-  Future<void> onEnter(state) async {
-    print('in onEnter');
-  }
-
-  @override
-  Future<void> onExit(state) async {
-    print('in onExit');
-  }
-
-  @override
-  Future<void> onChange(previous, next) async {
-    print('in onChange: $previous $next');
   }
 }
 

--- a/packages/state_machine_bloc/test/state_handler_test.dart
+++ b/packages/state_machine_bloc/test/state_handler_test.dart
@@ -1,0 +1,175 @@
+import 'package:state_machine_bloc/src/state_machine.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+sealed class Event {}
+
+class EventA extends Event {}
+
+class EventB extends Event {}
+
+class EventC extends Event {}
+
+sealed class State {
+  @override
+  bool operator ==(Object value) => false;
+
+  @override
+  int get hashCode => 0;
+}
+
+class StateA extends State {}
+
+class StateB extends State {}
+
+class StateC extends State {}
+
+class StateAHandler extends StateHandler<Event, State, StateA> {
+  @override
+  registerEventHandlers() {
+    on<EventA>(_onA);
+    on<EventA>(_onA);
+  }
+
+  StateB _onA(EventA event, StateA state) {
+    _onEvent(event);
+    return StateB();
+  }
+
+  @override
+  Future<void> onEnter(state) async {
+    print('in onEnter');
+  }
+
+  @override
+  Future<void> onExit(state) async {
+    print('in onExit');
+  }
+
+  @override
+  Future<void> onChange(previous, next) async {
+    print('in onChange: $previous $next');
+  }
+}
+
+void _onEvent(dynamic e) => eventsReceived.add(e.runtimeType.toString());
+List<String> eventsReceived = [];
+
+class StateBHandler extends StateHandler<Event, State, StateB> {
+  @override
+  registerEventHandlers() {
+    on<EventB>(_onB);
+  }
+
+  StateA _onB(EventB event, StateB state) {
+    _onEvent(event);
+    return StateA();
+  }
+
+  @override
+  Future<void> onEnter(state) async {
+    print('in onEnter');
+  }
+
+  @override
+  Future<void> onExit(state) async {
+    print('in onExit');
+  }
+
+  @override
+  Future<void> onChange(previous, next) async {
+    print('in onChange: $previous $next');
+  }
+}
+
+class StateCHandler extends StateHandler<Event, State, StateC> {
+  @override
+  registerEventHandlers() {
+    on<EventC>(_onCNull);
+    on<EventC>(_onC);
+  }
+
+  State? _onCNull(EventC event, StateC state) {
+    _onEvent(event);
+    return null;
+  }
+
+  StateA _onC(EventC event, StateC state) {
+    _onEvent(event);
+    return StateA();
+  }
+
+  @override
+  Future<void> onEnter(state) async {
+    print('in onEnter');
+  }
+
+  @override
+  Future<void> onExit(state) async {
+    print('in onExit');
+  }
+
+  @override
+  Future<void> onChange(previous, next) async {
+    print('in onChange: $previous $next');
+  }
+}
+
+class DummyStateMachine extends StateMachine<Event, State> {
+  DummyStateMachine([State? initial]) : super(initial ?? StateA()) {
+    defineHandler<StateA>(StateAHandler());
+    defineHandler<StateB>(StateBHandler());
+    defineHandler<StateC>(StateCHandler());
+  }
+}
+
+void main() {
+  group("StateHandler", () {
+    tearDown(() => eventsReceived.clear());
+    test("event handler that return null does not trigger a transition",
+        () async {
+      final sm = DummyStateMachine(StateC());
+      sm.add(EventC());
+
+      await wait();
+
+      expect(eventsReceived, ["EventC", "EventC"]);
+    });
+
+    test("events are received and evaluated sequentially", () async {
+      final sm = DummyStateMachine();
+      sm.add(EventB());
+      sm.add(EventB());
+      sm.add(EventA());
+      sm.add(EventA());
+      sm.add(EventA());
+      sm.add(EventB());
+
+      await wait();
+
+      expect(eventsReceived, ["EventA", "EventB"]);
+    });
+
+    test("events are evaluated sequentially until a transition happen",
+        () async {
+      final sm = DummyStateMachine();
+      sm.add(EventA());
+      sm.add(EventA());
+
+      await wait();
+
+      expect(eventsReceived, ["EventA"]);
+    });
+    test(
+        "if no event handler corresponding to the received event is registered for the current state, event is ignored",
+        () async {
+      final sm = DummyStateMachine();
+      sm.add(EventB());
+
+      await wait();
+
+      expect(eventsReceived, []);
+    });
+  });
+}


### PR DESCRIPTION
Adds an initial `StateHandler` abstraction. 


To use, you simply define a state handler: 

```
class StateAHandler extends StateHandler<Event, State, StateA> {
  @override
  registerEventHandlers() {
    on<EventA>(_onA);
  }

  StateB _onA(EventA event, StateA state) {
    return StateB();
  }

  @override
  Future<void> onEnter(state) async {
    print('in onEnter');
  }

  @override
  Future<void> onExit(state) async {
    print('in onExit');
  }

  @override
  Future<void> onChange(previous, next) async {
    print('in onChange: $previous $next');
  }
}
```

And then in your `StateMachine<Event, State>`, you simply call `registerHandler<State>(Handler())`:

```
class DummyStateMachine extends StateMachine<Event, State> {
  DummyStateMachine([State? initial]) : super(initial ?? StateA()) {
    defineHandler<StateA>(StateAHandler());
    defineHandler<StateB>(StateBHandler());
    defineHandler<StateC>(StateCHandler());
  }
}
```

Since `onEnter`, `onExit`, and `onChange` can only be defined once per state definition, I simply added those as methods that can be overridden if you need those handlers. The type signature is a `FutureOr<void>` type - so overrides can be async if needed - but the default implementations are no-op.

I hid some of the magic of the `StateDefinitionBuilder` and how an `add` function gets wired up so that implementations can call `add(event)`. I did this so you wouldn't have to pass down or otherwise explicitly inject a `add` method. The setter is public, so during a test you can explicitly set this value. Open to suggestions if we want to change these bits. Unsure we'd want to test the builder result - but we could also make that `_build()` method public from the package, and allow those definitions to be inspected / tested.

Another big use case here - is being able to produce side effects in the `onEnter` and similar methods. 

I think this should allow for that - as you can:
```
class StateAHandler extends StateHandler<Event, State, StateA> {
  StateAHandler({required this.service});
  
  final SomeService service;
 
  @override
  Future<void> onEnter(state) async {
    final result = await service.action();
    add(ActionResult(result));
  }
}

class DummyStateMachine extends StateMachine<Event, State> {
  final SomeService service;
  
  DummyStateMachine(SomeService service, [State? initial]) : super(initial ?? StateA()) {
    defineHandler<StateA>(StateAHandler(service: service));
  }
}
```

To test, I simply copied one of the test cases (events test) and utilized the existing tests.

This does NOT yet support nested states / handlers. Need to noodle on that and it's not exactly a priority for what we have now - although it could be useful.